### PR TITLE
Fixed missed remember input name in login forms

### DIFF
--- a/resources/stubs/ui/adminlte/views/auth/login.blade.php
+++ b/resources/stubs/ui/adminlte/views/auth/login.blade.php
@@ -38,7 +38,7 @@
             <div class="row">
                 <div class="col-8">
                     <div class="icheck-primary">
-                        <input type="checkbox" id="remember">
+                        <input type="checkbox" id="remember" name="remember">
                         <label for="remember">
                             {{ __('Remember Me') }}
                         </label>

--- a/resources/stubs/ui/voltbs5/views/auth/login.blade.php
+++ b/resources/stubs/ui/voltbs5/views/auth/login.blade.php
@@ -55,7 +55,7 @@
                             <!-- End of Form -->
                             <div class="d-flex justify-content-between align-items-top mb-4">
                                 <div class="form-check">
-                                    <input class="form-check-input" type="checkbox" value="" id="remember">
+                                    <input class="form-check-input" type="checkbox" name="remember" value="" id="remember">
                                     <label class="form-check-label mb-0" for="remember">
                                         {{ __('Remember me') }}
                                     </label>


### PR DESCRIPTION
These two items was missed in login.blade.php files
added `name="remember"` to missed parts.

thanks