### PR TITLE
Use tailwinds jit mode in notusjs theme by default

### DIFF
--- a/resources/stubs/breeze/notusjs/tailwind.config.js
+++ b/resources/stubs/breeze/notusjs/tailwind.config.js
@@ -3,6 +3,7 @@ const plugin = require("tailwindcss/plugin");
 const colors = require("tailwindcss/colors");
 
 module.exports = {
+    mode: 'jit',
     purge: [
         './vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php',
         './storage/framework/views/*.php',


### PR DESCRIPTION
Closes #52 
Enables tailwinds jit mode by default. Reduces css file size
![image](https://user-images.githubusercontent.com/11015977/145603045-ad29c92e-20db-4274-b17b-34778b5ac05f.png)
