### PR TITLE
Add Artisan Command Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ This package should be used **immediately after installing Laravel**. If you add
 4. Run `npm install && npm run dev`
 5. That's it, you have Laravel Auth starter, just visit the home page and click Log in / Register
 
+### Developing within a container
+
+Internally this package runs several `php artisan` commands during the install process. This command may not work and the installation process hang if you are within a container. Alternatively, you may pass the `--artisan_command` flag to change this behaviour. For example: `php artisan larastarters:install --artisan_command=./vendor/bin/sail` or `php artisan larastarters:install --artisan_command=sail`.
 
 ![Larastarters Install](https://laraveldaily.com/wp-content/uploads/2021/11/Screenshot-2021-11-02-at-10.36.03.png)
 

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -14,7 +14,8 @@ class InstallCommand extends Command
      * @var string
      */
     protected $signature = 'larastarters:install
-                            {--composer=global : Absolute path to the Composer binary which should be used to install packages}';
+                            {--composer=global : Absolute path to the Composer binary which should be used to install packages}
+                            {--a|artisan_command=php : The artisan command to run internaly}';
 
     /**
      * The console command description.
@@ -22,6 +23,13 @@ class InstallCommand extends Command
      * @var string
      */
     protected $description = 'Install one of the Larastarters Themes';
+
+    /**
+     * The artisan command to run. Default is php.
+     *
+     * @var string
+     */
+    protected string $artisan_command;
 
     /**
      * Create a new command instance.
@@ -40,6 +48,8 @@ class InstallCommand extends Command
      */
     public function handle()
     {
+        $this->artisan_command = $this->option('artisan_command');
+        
         $kit = $this->choice(
             'Which Laravel starter kit you want to use?',
             ['Laravel Breeze (Tailwind)', 'Laravel Breeze & Inertia (Tailwind)', 'Laravel UI (Bootstrap)'],
@@ -55,7 +65,7 @@ class InstallCommand extends Command
 
             // Install breeze
             $this->requireComposerPackages('laravel/breeze:^1.4');
-            shell_exec('php artisan breeze:install');
+            shell_exec("{$this->artisan_command} artisan breeze:install");
 
             file_put_contents(
                 base_path('routes/web.php'),
@@ -90,7 +100,7 @@ class InstallCommand extends Command
 
             // Install breeze
             $this->requireComposerPackages('laravel/breeze:^1.4');
-            shell_exec('php artisan breeze:install vue');
+            shell_exec("{$this->artisan_command} artisan breeze:install vue");
 
             file_put_contents(
                 base_path('routes/web.php'),
@@ -126,7 +136,7 @@ class InstallCommand extends Command
             );
 
             $this->requireComposerPackages('laravel/ui:^3.3');
-            shell_exec('php artisan ui bootstrap --auth');
+            shell_exec("{$this->artisan_command} artisan ui bootstrap --auth");
 
             file_put_contents(
                 base_path('routes/web.php'),


### PR DESCRIPTION
This option provide the ability to switch the `php` command for any
other, like `./vendor/bin/sail` or `foo`. Helpfull for when using
in a container. Also fix issue #76 causing the command to hang.