### PR TITLE
Removed profile destroy route

### DIFF
--- a/resources/stubs/routes.php
+++ b/resources/stubs/routes.php
@@ -30,7 +30,6 @@ Route::middleware('auth')->group(function () {
 
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
-    Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
Dear Laravel Daily Team,

I want to express my gratitude for the excellent Laravel starter that you provided. While exploring the routes file, I noticed that there is a route for _profile.destroy_, but I couldn't find the corresponding controller method. Additionally, I believe that it doesn't make sense to allow users to delete their own profile, and therefore, I propose to remove the route.

Thank you,
Rakib