### PR TITLE
Fixed The POST method is not supported for route password.

### DIFF
--- a/resources/stubs/breeze/inertia/windmill/js/Pages/Auth/ResetPassword.vue
+++ b/resources/stubs/breeze/inertia/windmill/js/Pages/Auth/ResetPassword.vue
@@ -64,7 +64,7 @@ const form = useForm({
 });
 
 const submit = () => {
-    form.post(route('password.update'), {
+    form.post(route('password.store'), {
         onFinish: () => form.reset('password', 'password_confirmation'),
     });
 };


### PR DESCRIPTION
Here's the fix for the [issue 128](https://github.com/LaravelDaily/Larastarters/issues/128). Glad to notice and provide a real quick solution to it. Hope this gets merged soon!

![image](https://user-images.githubusercontent.com/61485238/225688657-b151a525-1a2c-49da-a306-bfad7d877552.png)

Now you can reset your password in the vue inertia version of Windmill seamlessly!

[For more details](https://github.com/laravel/breeze/blob/1.x/stubs/inertia-vue/resources/js/Pages/Auth/ResetPassword.vue)