### PR TITLE
Removed inconsistent `dark:` class from sub menu

### DIFF
--- a/resources/stubs/breeze/inertia/windmill/js/Layouts/Navigation.vue
+++ b/resources/stubs/breeze/inertia/windmill/js/Layouts/Navigation.vue
@@ -62,9 +62,9 @@
                     clip-rule="evenodd"></path>
             </svg>
           </button>
-            <ul v-show="showingTwoLevelMenu" class="p-2 mt-2 space-y-2 overflow-hidden text-sm font-medium text-gray-500 rounded-md shadow-inner bg-gray-50 dark:text-gray-400 dark:bg-gray-900"
+            <ul v-show="showingTwoLevelMenu" class="p-2 mt-2 space-y-2 overflow-hidden text-sm font-medium text-gray-500 rounded-md shadow-inner bg-gray-50"
                 aria-label="submenu">
-              <li class="px-2 py-1 transition-colors duration-150 hover:text-gray-800 dark:hover:text-gray-200">
+              <li class="px-2 py-1 transition-colors duration-150 hover:text-gray-800">
                 <a class="w-full" href="#">Child menu</a>
               </li>
             </ul>


### PR DESCRIPTION
Dark classes have not been used anywhere but in the Two Level Menu. Imagine someone reuses the sub-menu and the UI will start looking inconsistent already.
![Screenshot_1](https://user-images.githubusercontent.com/61485238/226158560-1749fee8-0dd7-4430-9c91-fc58e5cdd85e.png)

That's why I made this little PR removing all those unnecessary `dark:` classes from navigation menus