### PR TITLE
useForm() and image source issue fixed

### DIFF
--- a/resources/stubs/breeze/inertia/windmill/js/Pages/Auth/VerifyEmail.vue
+++ b/resources/stubs/breeze/inertia/windmill/js/Pages/Auth/VerifyEmail.vue
@@ -5,7 +5,7 @@
     <div class="flex flex-col overflow-y-auto md:flex-row">
       <div class="h-32 md:h-auto md:w-1/2">
         <img aria-hidden="true" class="object-cover w-full h-full"
-             src="{{ asset('images/forgot-password-office.jpeg') }}" alt="Office"/>
+             src="/images/forgot-password-office.jpeg" alt="Office"/>
       </div>
       <div class="flex items-center justify-center p-6 sm:p-12 md:w-1/2">
         <div class="w-full">
@@ -41,7 +41,7 @@ import { Head, Link, useForm } from '@inertiajs/vue3';
 const props = defineProps({
     status: String,
 });
-const form = useForm();
+const form = useForm({});
 const submit = () => {
     form.post(route('verification.send'));
 };


### PR DESCRIPTION
useForm() cannot convert `undefined` to `object`, so we at least need to pass an empty `object` to make it work (Yeah, I was facing an issue while working with verify email feature).

And also, as we are not using blade here, so `asset()` function will not work as it would in a blade file.

_Seems like I'm learning so many new things while completing the Upper Beginner challenge of the Laravel Learning Roadmap 😀_

Thank You, Have a great day!